### PR TITLE
Fix the compilation on my system

### DIFF
--- a/ctlra/CMakeLists.txt
+++ b/ctlra/CMakeLists.txt
@@ -13,7 +13,7 @@ pkg_check_modules(ALSA alsa REQUIRED)
 include_directories( ${ALSA_INCLUDE_DIRS}  )
 link_directories   ( ${ALSA_LIBRARY_DIRS}  )
 
-SET(CMAKE_C_FLAGS " -g -fPIC -Wall -Wno-unused-variable ")
+SET(CMAKE_C_FLAGS " -std=c99 -g -fPIC -Wall -Wno-unused-variable ")
 
 if( ${ARCHITECTURE} STREQUAL "x86_64" )
   set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}"-msse2" )

--- a/ctlra/usb.c
+++ b/ctlra/usb.c
@@ -9,6 +9,19 @@
 
 #define USB_PATH_MAX 256
 
+#ifndef LIBUSB_HOTPLUG_MATCH_ANY
+#define LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT 0xdeadbeef
+#define LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED 0xdeadbeef
+#define LIBUSB_HOTPLUG_MATCH_ANY 0xdeadbeef
+#define LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER 0xdeadbeef
+#define LIBUSB_CAP_HAS_HOTPLUG 0xdeadbeef
+#warning "Please update your very old libusb version"
+#define libusb_hotplug_event int
+typedef int libusb_hotplug_callback_handle;
+int libusb_hotplug_register_callback() {return 0xcafe;};
+int libusb_set_auto_detach_kernel_driver() {return 0xcafe;}
+#endif
+
 /* From cltra.c */
 extern int ctlra_impl_get_id_by_vid_pid(uint32_t vid, uint32_t pid);
 extern int ctlra_impl_accept_dev(struct ctlra_t *ctlra, int dev_id);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,7 +28,9 @@ link_directories   ( ${X11_LIBRARY_DIRS}  )
 
 IF(RELEASE_BUILD)
   SET(CMAKE_CXX_FLAGS " -g -Wall -Wno-unused-variable ")
-  SET(CMAKE_C_FLAGS " -g -Wall -W -Wno-unused-variable ")
+  SET(CMAKE_C_FLAGS " -std=c99 -g -Wall -W -Wno-unused-variable ")
+else()
+  SET(CMAKE_C_FLAGS " -std=c99 ")
 ENDIF(RELEASE_BUILD)
 
 if( ${ARCHITECTURE} STREQUAL "x86_64" )


### PR DESCRIPTION
Fixes missing -std=c99 and missing libusb api for out-of-date libusb. As an aside, adding travis-ci is a good way to find issues like the missing -std=c99.