### PR TITLE
Generic MIDI backend

### DIFF
--- a/ctlra/devices/meson.build
+++ b/ctlra/devices/meson.build
@@ -1,5 +1,6 @@
 devices_src = files('3dconnexion.c',
                     'firmata.c',
+                    'midi_generic.c',
                     'ni_kontrol_f1.c',
                     'ni_kontrol_d2.c',
                     'ni_kontrol_x1_mk2.c',

--- a/ctlra/devices/midi_generic.c
+++ b/ctlra/devices/midi_generic.c
@@ -179,7 +179,7 @@ ctlra_midi_generic_connect(ctlra_event_func event_func, void *userdata,
 	return (struct ctlra_dev_t *)dev;
 fail:
 	free(dev);
-	return 0;
+	return NULL;
 }
 
 

--- a/ctlra/devices/midi_generic.c
+++ b/ctlra/devices/midi_generic.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017, OpenAV Productions,
+ * Harry van Haaren <harryhaaren@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "impl.h"
+#include "midi.h"
+
+#define CONTROLS_SIZE 512
+#define LIGHTS_SIZE 512
+
+#define AKAI    0x09e8
+#define APC40   0x0073
+#define MPKMINI 0x007c
+
+#define CTLRA_DRIVER_VENDOR AKAI
+#define CTLRA_DRIVER_DEVICE MPKMINI
+
+
+/* Represents the the hardware device */
+struct midi_generic_t {
+	/* base handles usb i/o etc */
+	struct ctlra_dev_t base;
+	/* midi i/o */
+	struct ctlra_midi_t *midi;
+	/* current value of each controller is stored here */
+	float hw_values[CONTROLS_SIZE];
+	uint8_t lights[LIGHTS_SIZE];
+};
+
+static uint32_t midi_generic_poll(struct ctlra_dev_t *base)
+{
+	struct midi_generic_t *dev = (struct midi_generic_t *)base;
+	ctlra_midi_input_poll(dev->midi);
+	return 0;
+}
+
+int midi_generic_midi_input_cb(uint8_t nbytes, uint8_t * buf, void *ud)
+{
+	struct midi_generic_t *dev = (struct midi_generic_t *)ud;
+
+	switch(buf[0] & 0xf0) {
+	case 0x90: /* Note On */
+	case 0x80: /* Note Off */ {
+		struct ctlra_event_t event = {
+			.type = CTLRA_EVENT_BUTTON,
+			.button  = {
+				.id = buf[1],
+				.pressed = buf[0] >= 0x90,
+				//."velocity" = buf[2] / 127.f;
+			},
+		};
+		struct ctlra_event_t *e = {&event};
+		dev->base.event_func(&dev->base, 1, &e,
+				     dev->base.event_func_userdata);
+		} break;
+
+	case 0xb0: /* control change */ {
+		struct ctlra_event_t event = {
+			.type = CTLRA_EVENT_SLIDER,
+			.slider  = {
+				.id = buf[1],
+				.value = buf[2] / 127.f
+			},
+		};
+		struct ctlra_event_t *e = {&event};
+		dev->base.event_func(&dev->base, 1, &e,
+				     dev->base.event_func_userdata);
+		}
+		break;
+	};
+
+	/*
+	// TODO: figure out how to do feedback to the device
+	if(buf[1] == 0x37) {
+		uint8_t out[] = {0x90, 0x37, 1 + 2 * (buf[0] == 0x80)};
+		ctlra_midi_output_write(dev->midi, 3, out);
+	}
+	*/
+	return 0;
+}
+
+static const char *
+midi_generic_control_get_name(enum ctlra_event_type_t type,
+			      uint32_t control)
+{
+	return "generic";
+}
+
+static void midi_generic_light_set(struct ctlra_dev_t *base,
+				    uint32_t light_id,
+				    uint32_t light_status)
+{
+	struct midi_generic_t *dev = (struct midi_generic_t *)base;
+}
+
+void
+midi_generic_light_flush(struct ctlra_dev_t *base, uint32_t force)
+{
+	struct midi_generic_t *dev = (struct midi_generic_t *)base;
+}
+
+static int32_t
+midi_generic_disconnect(struct ctlra_dev_t *base)
+{
+	struct midi_generic_t *dev = (struct midi_generic_t *)base;
+	memset(dev->lights, 0, sizeof(dev->lights));
+	free(dev);
+	return 0;
+}
+
+struct ctlra_dev_info_t ctlra_midi_generic_info;
+
+struct ctlra_dev_t *
+ctlra_midi_generic_connect(ctlra_event_func event_func,void *userdata,
+			   void *future)
+{
+	(void)future;
+	struct midi_generic_t *dev = calloc(1, sizeof(struct midi_generic_t));
+	if(!dev)
+		goto fail;
+
+	dev->midi = ctlra_midi_open("Ctlra Midi Generic",
+				    midi_generic_midi_input_cb, dev);
+	if(dev->midi == 0) {
+		printf("Ctlra: error opening midi i/o\n");
+		goto fail;
+	}
+
+	dev->base.info = ctlra_midi_generic_info;
+
+	dev->base.poll = midi_generic_poll;
+	dev->base.disconnect = midi_generic_disconnect;
+	dev->base.light_set = midi_generic_light_set;
+	dev->base.light_flush = midi_generic_light_flush;
+
+	dev->base.event_func = event_func;
+	dev->base.event_func_userdata = userdata;
+
+	return (struct ctlra_dev_t *)dev;
+fail:
+	free(dev);
+	return 0;
+}
+
+
+struct ctlra_dev_info_t ctlra_midi_generic_info = {
+	.vendor    = "OpenAV",
+	.device    = "Midi Generic",
+	.vendor_id = CTLRA_DRIVER_VENDOR,
+	.device_id = CTLRA_DRIVER_DEVICE,
+	.size_x    = 512,
+	.size_y    = 512,
+	.get_name =  midi_generic_control_get_name,
+};
+
+CTLRA_DEVICE_REGISTER(midi_generic)

--- a/ctlra/devices/midi_generic.c
+++ b/ctlra/devices/midi_generic.c
@@ -77,7 +77,8 @@ midi_generic_midi_input_cb(uint8_t nbytes, uint8_t * buf, void *ud)
 			.button  = {
 				.id = buf[1],
 				.pressed = buf[0] >= 0x90,
-				//."velocity" = buf[2] / 127.f;
+				.has_pressure = 1,
+				.pressure = buf[2] / 127.f,
 			},
 		};
 		struct ctlra_event_t *e = {&event};

--- a/ctlra/devices/midi_generic.c
+++ b/ctlra/devices/midi_generic.c
@@ -40,13 +40,10 @@
 #define CONTROLS_SIZE 512
 #define LIGHTS_SIZE 512
 
-#define AKAI    0x09e8
-#define APC40   0x0073
-#define MPKMINI 0x007c
+#define GENERIC 0x1
 
-#define CTLRA_DRIVER_VENDOR AKAI
-#define CTLRA_DRIVER_DEVICE MPKMINI
-
+#define CTLRA_DRIVER_VENDOR GENERIC
+#define CTLRA_DRIVER_DEVICE GENERIC
 
 /* Represents the the hardware device */
 struct midi_generic_t {

--- a/ctlra/event.h
+++ b/ctlra/event.h
@@ -63,7 +63,11 @@ struct ctlra_event_button_t {
 	/** The id of the button */
 	uint32_t id;
 	/** The state of the button */
-	uint8_t pressed;
+	uint8_t pressed : 1;
+	uint8_t has_pressure : 1;
+	uint8_t unused : 6;
+	/** Pressure or velocity of the button press/release */
+	float pressure;
 };
 
 #define CTLRA_EVENT_ENCODER_FLAG_INT   (1<<0)

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -48,13 +48,19 @@ void simple_event_func(struct ctlra_dev_t* dev, uint32_t num_events,
 		const char *pressed = 0;
 		const char *name = 0;
 		switch(e->type) {
-		case CTLRA_EVENT_BUTTON:
+		case CTLRA_EVENT_BUTTON: {
 			name = ctlra_info_get_name(&info, CTLRA_EVENT_BUTTON,
 						   e->button.id);
+			char pressure[16] = {0};
+			if(e->button.has_pressure) {
+				snprintf(pressure, sizeof(pressure),
+					 "%0.01f", e->button.pressure);
+			}
 			printf("[%s] button %s (%d)\n",
-			       e->button.pressed ? " X " : "   ",
-			       name, e->button.id);
-			break;
+				e->button.has_pressure ?  pressure :
+				(e->button.pressed ? " X " : "   "),
+				name, e->button.id);
+			} break;
 
 		case CTLRA_EVENT_ENCODER:
 			name = ctlra_info_get_name(&info, CTLRA_EVENT_ENCODER,


### PR DESCRIPTION
This PR includes a generic MIDI backend, that translates basic MIDI messages (Note On/Off and Control Changes) to Ctlra Events. This allows mapping of MIDI controllers into Ctlra enabled applications without the application being aware of MIDI messages.

In order to provide lots of flexibility on the feedback side, the light_set() API is re-used to be able to transmit the "normal" LED status updates as used by MIDI (0x90, light number, value), as well as a more advanced usage.

The advanced usage operates as follows: set light_id to `UINT32_MAX` to enable) after which the lowest 3 bytes of the `value` will be interpreted as raw MIDI message to be transmitted. This advanced mode enables controller feedback for devices that require it, and places the burden of this advanced control in the mapping layer. Note that the _application_ itself is still not aware of MIDI - only the mapping layer (aka; the TCC script in the case of current prototypes).

This PR relates to #15, which was requesting MIDI support. This PR (when merged) should close that issue.