### PR TITLE
Fix Screen/LED Strip define conflict, general improvements

### DIFF
--- a/ctlra/ctlra.h
+++ b/ctlra/ctlra.h
@@ -126,7 +126,7 @@ typedef const char *(*ctlra_info_get_name_func)(enum ctlra_event_type_t type,
 #define CTLRA_ITEM_LED_COLOR     (1<< 6)
 
 #define CTLRA_ITEM_FB_LED_STRIP  (1<< 7)
-#define CTLRA_ITEM_FB_SCREEN     (1<< 7)
+#define CTLRA_ITEM_FB_SCREEN     (1<< 8)
 
 #define CTLRA_ITEM_HAS_FB_ID     (1<<31)
 struct ctlra_item_info_t {

--- a/ctlra/devices/avtka.c
+++ b/ctlra/devices/avtka.c
@@ -456,6 +456,7 @@ ctlra_build_avtka_ui(struct cavtka_t *dev,
 
 		/* default draws a button if it is not understood */
 		ai.draw = AVTKA_DRAW_BUTTON;
+
 		/* LED strip */
 		if(item->flags & CTLRA_ITEM_FB_LED_STRIP) {
 			ai.draw = AVTKA_DRAW_LED_STRIP;
@@ -463,6 +464,7 @@ ctlra_build_avtka_ui(struct cavtka_t *dev,
 			ai.params[0] = item->params[1] - item->params[0];
 			ai.params[1] = item->params[2];
 		}
+
 		/* Screen */
 		if(item->flags & CTLRA_ITEM_FB_SCREEN) {
 			ai.draw = AVTKA_DRAW_BUTTON;

--- a/examples/device_test/device_test.c
+++ b/examples/device_test/device_test.c
@@ -1,5 +1,6 @@
 #define _DEFAULT_SOURCE
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <signal.h>
@@ -184,6 +185,11 @@ int accept_dev_func(const struct ctlra_dev_info_t *info,
 	led_count = info->control_count[CTLRA_FEEDBACK_ITEM];
 	if(led_count > NUM_LEDS)
 		led_count = NUM_LEDS;
+
+	/* dont device test a generic MIDI device - makes no sense! */
+	if(strcmp(info->vendor, "OpenAV") == 0 &&
+			strcmp(info->device, "Midi Generic") == 0)
+		return 0;
 
 	if(!avtka_ui) {
 		avtka_ui = ctlra_avtka_connect(simple_event_func,


### PR DESCRIPTION
Fix Screen/LED Strip define conflict, general improvements. Also ensure that the device-test binary doesn't create a UI for the MIDI Generic backend - because it blocks it being useful to use with other actual devices plugged in.