### PR TITLE
device/avtka: Add screen capabilities

### DIFF
--- a/examples/vegas_mode/mm_mk2.c
+++ b/examples/vegas_mode/mm_mk2.c
@@ -47,9 +47,7 @@ void mm_update_state(struct ctlra_dev_t *dev, void *ud)
 
 	uint8_t *pixel_data;
 	uint32_t bytes;
-	int has_screen = ctlra_dev_screen_get_data(dev,
-						   &pixel_data,
-						   &bytes, 0);
+	ctlra_dev_screen_get_data(dev, &pixel_data, &bytes, 0);
 
 	/* TODO: fix the bytes parameter, once a decision on the
 	 * general approach is made; see here for details:

--- a/examples/vegas_mode/mm_mk2.c
+++ b/examples/vegas_mode/mm_mk2.c
@@ -45,6 +45,21 @@ void mm_update_state(struct ctlra_dev_t *dev, void *ud)
 		break;
 	}
 
+	uint8_t *pixel_data;
+	uint32_t bytes;
+	int has_screen = ctlra_dev_screen_get_data(dev,
+						   &pixel_data,
+						   &bytes, 0);
+
+	/* TODO: fix the bytes parameter, once a decision on the
+	 * general approach is made; see here for details:
+	 * https://github.com/openAVproductions/openAV-Avtka/pull/5
+	 */
+	/* 128x64 pixels, RGB = 3 channels, Cairo Stride +1 */
+#define SIZE (128 * 64 * (3 + 1))
+	for(int i = 0; i < SIZE; i++)
+		pixel_data[i] = rand();
+
 	return;
 }
 


### PR DESCRIPTION
These changes enable basic functionality of a screen being shown up on the virtual device UIs. This allows developers to prototype code for controllers they don't have access to, and debug problems even when there's no hardware available.

Note that this branch *requires* the latest AVTKA code, as per this pull request:
https://github.com/openAVproductions/openAV-avtka/pull/5

Until that pull request hits mainline AVTKA, this PR is not expected to build.