### PR TITLE
maschine mikro mk2: rework and update

### DIFF
--- a/ctlra/devices/ni_maschine_mikro_mk2.c
+++ b/ctlra/devices/ni_maschine_mikro_mk2.c
@@ -450,19 +450,12 @@ ni_maschine_mikro_mk2_light_flush(struct ctlra_dev_t *base, uint32_t force)
 	uint8_t *data = &dev->lights_endpoint;
 	dev->lights_endpoint = 0x80;
 
-static double worst_write;
-	struct timeval tv1, tv2;
-	gettimeofday(&tv1, NULL);
-	write(dev->fd, data, LIGHTS_SIZE);
-	gettimeofday(&tv2, NULL);
-	double delta =
-		(double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
-		(double) (tv2.tv_sec - tv1.tv_sec);
-	if(delta > worst_write) {
-		printf ("worst write %f\n", delta);
-		worst_write = delta;
-	}
-
+	/* error handling in USB subsystem */
+	ctlra_dev_impl_usb_interrupt_write(base,
+					   USB_HANDLE_IDX,
+					   USB_ENDPOINT_WRITE,
+					   data,
+					   LIGHTS_SIZE + 1);
 }
 
 static int32_t

--- a/ctlra/devices/ni_maschine_mikro_mk2.c
+++ b/ctlra/devices/ni_maschine_mikro_mk2.c
@@ -305,7 +305,7 @@ ni_maschine_mikro_mk2_usb_read_cb(struct ctlra_dev_t *base,
 
 				if(med > 550 && dev->pads[i] == 0) {
 					/* TODO: improve velocity linearity */
-					float velo = (dev->pad_avg[i] - 200) / 200.f;
+					float velo = (med - 550) / 3500.f;
 					float v2 = velo * velo * velo * velo;
 					float fin = (velo - v2) * 3;
 					fin = fin > 1.0f ? 1.0f : fin;


### PR DESCRIPTION
Large rework and updates for the mikro mk2, including using LibUSB as a backend, improvements to the filtering of the pad data (better note-press detection), and initial enabling of pushing bits to the screen.