### PR TITLE
usb: improve error message to indicate root cause

### DIFF
--- a/ctlra/usb.c
+++ b/ctlra/usb.c
@@ -365,8 +365,8 @@ int ctlra_dev_impl_usb_open_interface(struct ctlra_dev_t *ctlra_dev,
 	ret = libusb_claim_interface(handle, interface);
 	if(ret != LIBUSB_SUCCESS) {
 		CTLRA_ERROR(ctlra,
-			    "Ctlra: Could not claim interface %d of dev %s, continuing...\n",
-			    interface, ctlra_dev->info.device);
+			    "Ctlra: Could not claim device %s, is it already in use?\n",
+			    ctlra_dev->info.device);
 		int kernel_active = libusb_kernel_driver_active(handle,
 		                    interface);
 		if(kernel_active)


### PR DESCRIPTION
When another (Ctlra based, or otherwise) application already
has access to a controller, it is not available for "claiming"
in the USB code. Improve the error message to indicate that
the root cause is probably that another application is already
using the device.

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>