### PR TITLE
Build options for MIDI and Firmata backends

### DIFF
--- a/ctlra/devices/meson.build
+++ b/ctlra/devices/meson.build
@@ -1,5 +1,4 @@
 devices_src = files('3dconnexion.c',
-                    'midi_generic.c',
                     'ni_kontrol_f1.c',
                     'ni_kontrol_d2.c',
                     'ni_kontrol_x1_mk2.c',
@@ -8,6 +7,9 @@ devices_src = files('3dconnexion.c',
                     'ni_maschine_jam.c',
                     'ni_maschine_mikro_mk2.c')
 
+if get_option('midi')
+  devices_src += files('midi_generic.c')
+endif
 if (get_option('firmata') == true)
   devices_src += files('firmata.c')
 endif

--- a/ctlra/devices/meson.build
+++ b/ctlra/devices/meson.build
@@ -1,5 +1,4 @@
 devices_src = files('3dconnexion.c',
-                    'firmata.c',
                     'midi_generic.c',
                     'ni_kontrol_f1.c',
                     'ni_kontrol_d2.c',
@@ -9,6 +8,9 @@ devices_src = files('3dconnexion.c',
                     'ni_maschine_jam.c',
                     'ni_maschine_mikro_mk2.c')
 
+if (get_option('firmata') == true)
+  devices_src += files('firmata.c')
+endif
 if (get_option('avtka') == true)
   devices_src += files('avtka.c')
 endif

--- a/ctlra/meson.build
+++ b/ctlra/meson.build
@@ -1,5 +1,9 @@
 ctlra_hdr = files('ctlra.h', 'event.h')
-ctlra_src = files('ctlra.c', 'event.c', 'usb.c', 'midi.c')
+ctlra_src = files('ctlra.c', 'event.c', 'usb.c')
+
+if get_option('midi')
+  ctlra_src += files('midi.c')
+endif
 
 jack   = dependency('jack', required: false)
 conf_data.set('jack', jack.found())

--- a/ctlra/meson.build
+++ b/ctlra/meson.build
@@ -14,19 +14,33 @@ alsa   = dependency('alsa', required: false)
 conf_data.set('alsa', alsa.found())
 gl     = dependency('gl', required: false)
 
+ctlra_lib_deps_impl = [libusb, gl]
+
+if avtka_dep.found()
+  ctlra_lib_deps_impl += avtka_dep
+endif
+
+if get_option('firmata')
+  ctlra_lib_deps_impl += firmata_dep
+endif
+
+if alsa.found()
+  ctlra_lib_deps_impl += alsa
+endif
+
 devices_lib = static_library('ctlra_devices', devices_src,
     c_args: cargs,
     install : false,
-    include_directories : firmatac_includes,
+    include_directories : ctlra_lib_incs,
     link_args : '-Wl,--whole-archive',
-    dependencies: [libusb, alsa, avtka_dep, gl, firmatac_dep])
+    dependencies: ctlra_lib_deps_impl)
 
 ctlra = library('ctlra',
     [ctlra_src],
     c_args: cargs,
     install : true,
     link_whole : devices_lib,
-    dependencies: [libusb, alsa, avtka_dep, gl])
+    dependencies: ctlra_lib_deps_impl)
 
 configure_file(input : 'config.h.in',
                output : 'config.h',

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ cc  = meson.get_compiler('c')
 
 required_libs = ['libusb-1.0', 'alsa']
 
+ctlra_lib_incs = []
+
 avtka_dep = dependency('openav_avtka', required: false)
 if(get_option('avtka') == true)
     if (not avtka_dep.found())
@@ -18,12 +20,13 @@ if(get_option('avtka') == true)
     add_project_arguments('-DHAVE_AVTKA', language : 'c')
     required_libs += 'openav_avtka'
 endif
+ctlra_lib_deps = avtka_dep
 
-firmatac = subproject('firmatac')
-firmatac_dep = firmatac.get_variable('firmatac_dep')
-#required_libs += 'firmata_dep'
-
-firmatac_includes = include_directories('subprojects/firmatac/includes')
+if get_option('firmata')
+  firmatac = subproject('firmatac')
+  firmata_dep = firmatac.get_variable('firmatac_dep')
+  ctlra_lib_incs += include_directories('subprojects/firmatac/includes')
+endif
 
 subdir('ctlra')
 

--- a/meson.build
+++ b/meson.build
@@ -41,15 +41,17 @@ executable('simple',
            include_directories: ctlra_includes,
            link_with: ctlra)
 
-executable('daemon',
-           example_daemon,
-           include_directories: ctlra_includes,
-           link_with: ctlra)
+if get_option('midi')
+  executable('daemon',
+             example_daemon,
+             include_directories: ctlra_includes,
+             link_with: ctlra)
 
-executable('sequencer',
-           example_seq,
-           include_directories: ctlra_includes,
-           link_with: ctlra)
+  executable('sequencer',
+             example_seq,
+             include_directories: ctlra_includes,
+             link_with: ctlra)
+endif
 
 if(get_option('avtka') == true)
  if(avtka_dep.found())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('avtka', type : 'boolean', value : true, description : 'Use Avtka library for virtual controller support')
+option('firmata', type : 'boolean', value : false, description : 'Use Firmatac library for serial devices')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('avtka', type : 'boolean', value : true, description : 'Use Avtka library for virtual controller support')
 option('firmata', type : 'boolean', value : false, description : 'Use Firmatac library for serial devices')
+option('midi', type : 'boolean', value : false, description : 'Enable MIDI (only ALSA implemented, so Linux')


### PR DESCRIPTION
This reduces the required dependencies to of Ctlra. Particularly Firmata is not ideal, as it currently has Linux specific includes - while the MIDI backend cannot work on any other platform than Linux as it is using ALSA natively.