### PR TITLE
meson: refactor building of examples

### DIFF
--- a/ctlra/meson.build
+++ b/ctlra/meson.build
@@ -1,10 +1,6 @@
 ctlra_hdr = files('ctlra.h', 'event.h')
 ctlra_src = files('ctlra.c', 'event.c', 'usb.c')
 
-if get_option('midi')
-  ctlra_src += files('midi.c')
-endif
-
 jack   = dependency('jack', required: false)
 conf_data.set('jack', jack.found())
 
@@ -14,8 +10,7 @@ cargs = ['-Wno-unused-variable']
 
 libusb = dependency('libusb-1.0')
 conf_data.set('libusb', libusb.found())
-alsa   = dependency('alsa', required: false)
-conf_data.set('alsa', alsa.found())
+conf_data.set('alsa', midi_dep.found())
 gl     = dependency('gl', required: false)
 
 ctlra_lib_deps_impl = [libusb, gl]
@@ -28,8 +23,9 @@ if get_option('firmata')
   ctlra_lib_deps_impl += firmata_dep
 endif
 
-if alsa.found()
-  ctlra_lib_deps_impl += alsa
+if midi_dep.found()
+  ctlra_lib_deps_impl += midi_dep
+  ctlra_src += files('midi.c')
 endif
 
 devices_lib = static_library('ctlra_devices', devices_src,

--- a/examples/avtka_ctlra/meson.build
+++ b/examples/avtka_ctlra/meson.build
@@ -1,0 +1,2 @@
+example_src = files('avtka.c')
+dependencies = [avtka_dep, cairo_dep]

--- a/examples/daemon/meson.build
+++ b/examples/daemon/meson.build
@@ -1,0 +1,2 @@
+example_src = files('daemon.c')
+dependencies = midi_dep

--- a/examples/device_test/meson.build
+++ b/examples/device_test/meson.build
@@ -1,0 +1,2 @@
+example_src = files('device_test.c')
+dependencies = [avtka_dep, cairo_dep]

--- a/examples/loopa/meson.build
+++ b/examples/loopa/meson.build
@@ -1,0 +1,3 @@
+example_src = files('loopa.c', 'loopa_mk3.c', 'main.c')
+link_args = ['-ltcc', '-ldl']
+dependencies = [jack_dep, sndfile_dep, fluidsynth_dep, cairo_dep, m_dep]

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,8 +1,28 @@
-example_simple = files('simple/simple.c')
-example_avtka = files('avtka_ctlra/avtka.c')
-example_dev_test = files('device_test/device_test.c')
-example_daemon = files('daemon/daemon.c')
-example_virt_dev = files('virt_dev/virt_dev.c')
+# Portable math library linking
+m_dep = cc.find_library('m', required : false)
+
+# Example specific deps - these *MUST* be required : false
+jack_dep = dependency('jack', required: false)
+sndfile_dep    = dependency('sndfile', required: false)
+fluidsynth_dep = dependency('fluidsynth', required: false)
+
+
+foreach name: get_option('examples').split(',')
+  example_src = []
+  dependencies = []
+  link_args = []
+
+  subdir(name)
+
+  executable('ctlra_' + name,
+             example_src,
+             include_directories: ctlra_includes,
+             dependencies : dependencies,
+             link_args : link_args,
+             link_with: ctlra)
+endforeach
+
+
 example_loopa = files('loopa/loopa.c', 'loopa/main.c')
 
 # To properly install resources into /usr/share etc

--- a/examples/select_device/meson.build
+++ b/examples/select_device/meson.build
@@ -1,0 +1,7 @@
+example_src = files('main.c')
+gtk3_dep = dependency('gtk+-3.0', required: false)
+if not gtk3_dep.found()
+  gtk3_dep = disabler()
+endif
+
+dependencies = gtk3_dep

--- a/examples/sequencer/meson.build
+++ b/examples/sequencer/meson.build
@@ -1,0 +1,2 @@
+example_src = files('seq.c', 'sequencer.c')
+dependencies = midi_dep

--- a/examples/simple/meson.build
+++ b/examples/simple/meson.build
@@ -1,0 +1,1 @@
+example_src = files('simple.c')

--- a/examples/tcc_script/meson.build
+++ b/examples/tcc_script/meson.build
@@ -1,0 +1,2 @@
+example_src = files('tcc_script.c')
+link_args = ['-ltcc', '-ldl']

--- a/examples/virt_dev/meson.build
+++ b/examples/virt_dev/meson.build
@@ -1,0 +1,2 @@
+example_src = files('virt_dev.c')
+dependencies = [avtka_dep, cairo_dep]

--- a/meson.build
+++ b/meson.build
@@ -34,88 +34,27 @@ else
   conf_data.set('HAVE_TCC', 0)
 endif
 
+midi_dep = dependency('alsa', required: false)
+if not midi_dep.found()
+  midi_dep = disabler()
+  message('MIDI = disabler')
+endif
+
 subdir('ctlra')
 
 install_headers(ctlra_hdr, subdir : 'ctlra')
-
-subdir('examples')
 ctlra_includes = include_directories('ctlra')
+
+cairo_dep = dependency('cairo', required: false)
+
+if (get_option('examples') != '')
+	subdir('examples')
+endif
 
 # To copy files to the build directory
 configure_file(input : 'examples/loopa/loopa_mk3.c',
     output : 'loopa_mk3.c',
     configuration : configuration_data())
-
-executable('simple',
-           example_simple,
-           include_directories: ctlra_includes,
-           link_with: ctlra)
-
-executable('avtka',
-           example_avtka,
-           include_directories: ctlra_includes,
-           link_with: ctlra,
-           dependencies: avtka_dep)
-
-if get_option('midi')
-  executable('daemon',
-             example_daemon,
-             include_directories: ctlra_includes,
-             link_with: ctlra)
-
-  executable('sequencer',
-             example_seq,
-             include_directories: ctlra_includes,
-             link_with: ctlra)
-endif
-
-if(get_option('avtka') == true)
- if(avtka_dep.found())
-  executable('virt_dev',
-             example_virt_dev,
-             include_directories: ctlra_includes,
-             dependencies: avtka_dep,
-             link_with: ctlra)
-
-  executable('device_test',
-             example_dev_test,
-             include_directories: ctlra_includes,
-             dependencies: avtka_dep,
-             link_with: ctlra)
-  endif
-endif
-
-cairo   = dependency('cairo', required: false)
-sndfile = dependency('sndfile', required: false)
-fluid   = dependency('fluidsynth', required: false)
-if(jack.found() and cairo.found() and sndfile.found() and fluid.found())
-executable('vegas_mode',
-           example_vegas,
-           include_directories: ctlra_includes,
-           link_with: ctlra,
-           dependencies: [jack, cairo, sndfile, fluid])
-endif
-
-# FAUST code requires powf()
-m_dep = cc.find_library('m', required : false)
-
-
-if conf_data.get('HAVE_TCC') == 1
-  executable('loopa',
-             example_loopa,
-             include_directories: ctlra_includes,
-             link_with: ctlra,
-             link_args : ['-ltcc', '-ldl'],
-             dependencies: [jack, cairo, sndfile, fluid, m_dep])
-endif
-
-gtkdep = dependency('gtk+-3.0', required: false)
-if gtkdep.found()
-  executable('select_device',
-      'examples/select_device/main.c',
-      link_with : ctlra,
-      dependencies : gtkdep)
-endif
 
 pkg = import('pkgconfig')
 pkg.generate(name: 'openav_ctlra',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('avtka', type : 'boolean', value : true, description : 'Use Avtka library for virtual controller support')
 option('firmata', type : 'boolean', value : false, description : 'Use Firmatac library for serial devices')
 option('midi', type : 'boolean', value : false, description : 'Enable MIDI (only ALSA implemented, so Linux')
+option('examples', type: 'string', value: '', description: 'Comma-separated list of examples to build')


### PR DESCRIPTION
This takes the comma-seperated-list approach and greatly
simplifies and cleans up the build config. Disabler()
objects allow disabling examples based on which dependencies
are available - again simplifying the build.

To compile all examples, run:

meson configure -Dexamples=simple,daemon,avtka_ctlra,select_device,sequencer,virt_dev,device_test,tcc_script,loopa,vegas_mode

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>