### PR TITLE
Optimize Cairo to Device Screen code

### DIFF
--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -147,7 +147,8 @@ int32_t simple_screen_redraw_func(struct ctlra_dev_t *dev,
 	static cairo_surface_t *img;
 	static cairo_t *cr;
 	if(!img) {
-		img = cairo_image_surface_create(CAIRO_FORMAT_RGB24,
+		//img = cairo_image_surface_create(CAIRO_FORMAT_RGB24,
+		img = cairo_image_surface_create(CAIRO_FORMAT_RGB16_565,
 						 480, 272);
 		cr = cairo_create(img);
 	}

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -147,6 +147,7 @@ int32_t simple_screen_redraw_func(struct ctlra_dev_t *dev,
 	static cairo_surface_t *img;
 	static cairo_t *cr;
 	if(!img) {
+		/* TODO: cleanup img / cr */
 		//img = cairo_image_surface_create(CAIRO_FORMAT_RGB24,
 		img = cairo_image_surface_create(CAIRO_FORMAT_RGB16_565,
 						 480, 272);
@@ -158,15 +159,43 @@ int32_t simple_screen_redraw_func(struct ctlra_dev_t *dev,
 	cairo_rectangle(cr, 0, 0, 480, 272);
 	cairo_fill(cr);
 
-	cairo_set_source_rgb(cr, 1, 0, 1);
-	cairo_rectangle(cr, 10, 10, 10, 10);
-	cairo_fill(cr);
+	int x = 32;
+	int xoff = 62;
+
 	cairo_set_source_rgb(cr, 1, 0, 0);
-	cairo_rectangle(cr, 30, 10, 10, 10);
+	cairo_rectangle(cr, x, 20, 40, 40);
 	cairo_fill(cr);
+	x += xoff;
+
+	cairo_set_source_rgb(cr, 0, 1, 0);
+	cairo_rectangle(cr, x, 20, 40, 40);
+	cairo_fill(cr);
+	x += xoff;
+
+	cairo_set_source_rgb(cr, 0, 0, 1);
+	cairo_rectangle(cr, x, 20, 40, 40);
+	cairo_fill(cr);
+	x += xoff;
+
+	cairo_set_source_rgb(cr, 1, 1, 0);
+	cairo_rectangle(cr, x, 20, 40, 40);
+	cairo_fill(cr);
+	x += xoff;
+
+	cairo_set_source_rgb(cr, 1, 0, 1);
+	cairo_rectangle(cr, x, 20, 40, 40);
+	cairo_fill(cr);
+	x += xoff;
+
 	cairo_set_source_rgb(cr, 0, 1, 1);
-	cairo_rectangle(cr, xoff, 10, 10, 10);
+	cairo_rectangle(cr, x, 20, 40, 40);
 	cairo_fill(cr);
+	x += xoff;
+
+	cairo_set_source_rgb(cr, 1, 1, 1);
+	cairo_rectangle(cr, x, 20, 40, 40);
+	cairo_fill(cr);
+	x += xoff;
 
 	if(screen_idx == 0) {
 		/* draw screen A */


### PR DESCRIPTION
This PR improves the ctlra-cairo integration by optimizing the cairo-565 to device-565 implementation. As a result of this commit, the conversion functions reduces from ~12% to ~0.4%...  ~25x improvement :)