### PR TITLE
Mk3 and MIDI Fixes

### DIFF
--- a/ctlra/devices/ni_maschine_mk3.c
+++ b/ctlra/devices/ni_maschine_mk3.c
@@ -627,7 +627,10 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 		break;
 	case 42: {
 		/* pedal */
-		int pedal = buf[3] > 0;
+		// AG: 0x40 = bit mask for pedal; we *must* test for this
+		// specific value, since other bits of this byte may also be
+		// set by some of the buttons (see below)
+		int pedal = buf[3] & 0x40;
 		if(pedal != dev->pedal) {
 			//printf("PEDAL: %d, inv = %d\n", pedal, !pedal);
 			struct ctlra_event_t event[] = {
@@ -676,7 +679,16 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 			int offset = buttons[i].buf_byte_offset;
 			int mask   = buttons[i].mask;
 
+#if 0
+// AG XXXFIXME: Why should we read a 16 bit value here, only to mask out the
+// MSB immediately? (Note that all the button masks are single-byte.) Also,
+// the byte offsets for the various buttons are consecutive, so we'd actually
+// be reading overlapping values here. This just doesn't make any sense to me.
 			uint16_t v = *((uint16_t *)&buf[offset]) & mask;
+#else
+// This should work just as well.
+			uint16_t v = buf[offset] & mask;
+#endif
 			int value_idx = i;
 
 			if(dev->hw_values[value_idx] != v) {

--- a/ctlra/devices/ni_maschine_mk3.c
+++ b/ctlra/devices/ni_maschine_mk3.c
@@ -233,16 +233,18 @@ static const struct ni_maschine_mk3_ctlra_t buttons[] = {
 #define BUTTONS_SIZE (sizeof(buttons) / sizeof(buttons[0]))
 
 #define MK3_BTN (CTLRA_ITEM_BUTTON | CTLRA_ITEM_LED_INTENSITY | CTLRA_ITEM_HAS_FB_ID)
+#define MK3_BTN_NOFB (CTLRA_ITEM_BUTTON | CTLRA_ITEM_LED_INTENSITY)
 static struct ctlra_item_info_t buttons_info[] = {
 	/* TODO: represent encoders better in the UI */
 	/* encoder press, right up left down */
-	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	/* shift, top-right above screen (mad ordering..) */
+	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 60},
+	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 58},
+	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 59},
+	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 61},
+	/* shift */
 	{.x =  94, .y = 268, .w = 24, .h = 14, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 44},
+	/* top-right (button 8) above screen, 1-7 are below (mad ordering..) */
 	{.x = 278, .y =  10, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 19},
 	/* group ABCDEFGH */
 	{.x =  9, .y = 210, .w = 24,  .h = 14, .flags = MK3_BTN, .colour = 0xffffffff, .fb_id = 29},
@@ -278,7 +280,7 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 137, .y = 248, .w = 24, .h = 14, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 56},
 	{.x = 137, .y = 266, .w = 24, .h = 14, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 57},
 	/* Pitch, Mod, Perform */
-	{.x =  9, .y = 170, .w = 24, .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
+	{.x =  9, .y = 170, .w = 24, .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 25},
 	{.x = 37, .y = 170, .w = 24, .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 26},
 	{.x = 65, .y = 170, .w = 24, .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 27},
 	/* restart, erase, tap, follow */
@@ -304,7 +306,7 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 9, .y =  62, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 6},
 	{.x = 9, .y =  74, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 8},
 	{.x = 9, .y =  86, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 10},
-	/* Top buttons (7, 8 already above) */
+	/* Top buttons (8 already above) */
 	{.x =  82, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 12},
 	{.x = 110, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 13},
 	{.x = 138, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 14},
@@ -312,18 +314,18 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 194, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 16},
 	{.x = 222, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 17},
 	{.x = 250, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 18},
-	{.x = 278, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 19},
 	/* TODO: show encoder dial touch control */
 	/* big dial encoder touch */
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
 	/* 1-8 dial encoder touch */
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
-	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
+	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},
 };
 
 static struct ctlra_item_info_t sliders_info[] = {
@@ -424,7 +426,10 @@ struct ni_maschine_mk3_t {
 	/* base handles usb i/o etc */
 	struct ctlra_dev_t base;
 	/* current value of each controller is stored here */
-	float hw_values[CONTROLS_SIZE];
+	// AG: These appear to spit out some random values initially, which we
+	// just record on the first run without passing them on. Same applies
+	// to the big encoder and the touchstrip below.
+	float hw_values[CONTROLS_SIZE], hw_init[CONTROLS_SIZE];
 	/* current state of the lights, only flush on dirty */
 	uint8_t lights_dirty;
 	uint8_t lights_pads_dirty;
@@ -440,8 +445,8 @@ struct ni_maschine_mk3_t {
 	/* state of the pedal, according to the hardware */
 	uint8_t pedal;
 
-	uint8_t encoder_value;
-	uint16_t touchstrip_value;
+	uint8_t encoder_value, encoder_init;
+	uint16_t touchstrip_value, touchstrip_init;
 	/* Pressure filtering for note-onset detection */
 	uint64_t pad_last_msg_time;
 	uint16_t pad_hit;
@@ -540,9 +545,7 @@ ni_maschine_mk3_pads_decode_set(struct ni_maschine_mk3_t *dev,
 		if(current == new)
 			continue;
 
-		/* rotate grid to match order on device (but zero
-		 * based counting instead of 1 based). */
-		event.grid.pos = (3-(i/4))*4 + (i%4);
+		event.grid.pos = i;
 		int press = new > 0;
 		event.grid.pressed = press;
 		event.grid.pressure = pad_pressures[i] * (1 / 4096.f) * press;
@@ -626,7 +629,7 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 		/* pedal */
 		int pedal = buf[3] > 0;
 		if(pedal != dev->pedal) {
-			printf("PEDAL: %d, inv = %d\n", pedal, !pedal);
+			//printf("PEDAL: %d, inv = %d\n", pedal, !pedal);
 			struct ctlra_event_t event[] = {
 				{ .type = CTLRA_EVENT_BUTTON,
 				  .button  = {
@@ -650,7 +653,10 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 
 		/* touchstrip: dont send event if 0, as this is release */
 		uint16_t v = *((uint16_t *)&buf[30]);
-		if(v && v != dev->touchstrip_value) {
+		if(!dev->touchstrip_init) {
+			dev->touchstrip_value = v;
+			dev->touchstrip_init = 1;
+		} else if(v && v != dev->touchstrip_value) {
 			struct ctlra_event_t event = {
 				.type = CTLRA_EVENT_SLIDER,
 				.slider = {
@@ -695,7 +701,10 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 			const float value = v / 1000.f;
 			const uint8_t idx = BUTTONS_SIZE + i;
 
-			if(dev->hw_values[idx] != value) {
+			if(!dev->hw_init[idx]) {
+				dev->hw_values[idx] = value;
+				dev->hw_init[idx] = 1;
+			} else if(dev->hw_values[idx] != value) {
 				const float d = (value - dev->hw_values[idx]);
 				if(fabsf(d) > 0.7) {
 					/* wrap around */
@@ -729,7 +738,10 @@ ni_maschine_mk3_usb_read_cb(struct ctlra_dev_t *base,
 		};
 		struct ctlra_event_t *e = {&event};
 		int8_t enc   = buf[11] & 0x0f;
-		if(enc != dev->encoder_value) {
+		if(!dev->encoder_init) {
+			dev->encoder_value = enc;
+			dev->encoder_init = 1;
+		} else if(enc != dev->encoder_value) {
 			int dir = ctlra_dev_encoder_wrap_16(enc, dev->encoder_value);
 			event.encoder.delta = dir;
 			dev->encoder_value = enc;
@@ -751,8 +763,7 @@ static void ni_maschine_mk3_light_set(struct ctlra_dev_t *base,
 	if(!dev)
 		return;
 
-	// TODO: debug the -1, why is it required to get the right size?
-	if(light_id > (LIGHTS_SIZE + 25 + 16) - 1)
+	if(light_id >= (LIGHTS_SIZE + 25 + 16))
 		return;
 
 	int idx = light_id;

--- a/ctlra/devices/ni_maschine_mk3.c
+++ b/ctlra/devices/ni_maschine_mk3.c
@@ -69,7 +69,6 @@ static const char *ni_maschine_mk3_control_names[] = {
 	"Enc. Left",
 	"Enc. Down",
 	"Shift",
-	"Top 8",
 	"A",
 	"B",
 	"C",
@@ -126,6 +125,7 @@ static const char *ni_maschine_mk3_control_names[] = {
 	"Top 5",
 	"Top 6",
 	"Top 7",
+	"Top 8",
 	"Enc. Touch",
 	"Enc. Touch 8",
 	"Enc. Touch 7",
@@ -146,9 +146,8 @@ static const struct ni_maschine_mk3_ctlra_t buttons[] = {
 	{1, 1, 0x04},
 	{1, 1, 0x20},
 	{1, 1, 0x10},
-	/* shift, top right above screen */
+	/* shift */
 	{1, 1, 0x40},
-	{1, 1, 0x80},
 	/* group buttons ABCDEFGH */
 	{1, 2, 0x01},
 	{1, 2, 0x02},
@@ -218,6 +217,9 @@ static const struct ni_maschine_mk3_ctlra_t buttons[] = {
 	{1, 9, 0x10},
 	{1, 9, 0x20},
 	{1, 9, 0x40},
+	// AG: note that "Top 8" is actually stored in the first byte, NI
+	// probably crammed it in there to save an extra byte
+	{1, 1, 0x80},
 	/* Encoder Touch */
 	{1, 9, 0x80},
 	/* Dial touch 8 - 1 */
@@ -244,8 +246,6 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 21, .y = 138, .w = 18,  .h = 10, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 61},
 	/* shift */
 	{.x =  94, .y = 268, .w = 24, .h = 14, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 44},
-	/* top-right (button 8) above screen, 1-7 are below (mad ordering..) */
-	{.x = 278, .y =  10, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 19},
 	/* group ABCDEFGH */
 	{.x =  9, .y = 210, .w = 24,  .h = 14, .flags = MK3_BTN, .colour = 0xffffffff, .fb_id = 29},
 	{.x = 37, .y = 210, .w = 24,  .h = 14, .flags = MK3_BTN, .colour = 0xffffffff, .fb_id = 30},
@@ -306,7 +306,7 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 9, .y =  62, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 6},
 	{.x = 9, .y =  74, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 8},
 	{.x = 9, .y =  86, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 10},
-	/* Top buttons (8 already above) */
+	/* Top buttons */
 	{.x =  82, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 12},
 	{.x = 110, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 13},
 	{.x = 138, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 14},
@@ -314,6 +314,7 @@ static struct ctlra_item_info_t buttons_info[] = {
 	{.x = 194, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 16},
 	{.x = 222, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 17},
 	{.x = 250, .y = 10, .w = 24,  .h = 8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 18},
+	{.x = 278, .y =  10, .w = 24, .h =  8, .flags = MK3_BTN, .colour = 0xff000000, .fb_id = 19},
 	/* TODO: show encoder dial touch control */
 	/* big dial encoder touch */
 	{.x = 1, .y = 1, .w = 1, .h = 1, .flags = MK3_BTN_NOFB, .colour = 0xff000000, .fb_id = 0},

--- a/ctlra/devices/ni_maschine_mk3.c
+++ b/ctlra/devices/ni_maschine_mk3.c
@@ -127,14 +127,14 @@ static const char *ni_maschine_mk3_control_names[] = {
 	"Top 7",
 	"Top 8",
 	"Enc. Touch",
-	"Enc. Touch 8",
-	"Enc. Touch 7",
-	"Enc. Touch 6",
-	"Enc. Touch 5",
-	"Enc. Touch 4",
-	"Enc. Touch 3",
-	"Enc. Touch 2",
 	"Enc. Touch 1",
+	"Enc. Touch 2",
+	"Enc. Touch 3",
+	"Enc. Touch 4",
+	"Enc. Touch 5",
+	"Enc. Touch 6",
+	"Enc. Touch 7",
+	"Enc. Touch 8",
 };
 #define CONTROL_NAMES_SIZE (sizeof(ni_maschine_mk3_control_names) /\
 			    sizeof(ni_maschine_mk3_control_names[0]))
@@ -222,15 +222,15 @@ static const struct ni_maschine_mk3_ctlra_t buttons[] = {
 	{1, 1, 0x80},
 	/* Encoder Touch */
 	{1, 9, 0x80},
-	/* Dial touch 8 - 1 */
-	{1, 10, 0x01},
-	{1, 10, 0x02},
-	{1, 10, 0x04},
-	{1, 10, 0x08},
-	{1, 10, 0x10},
-	{1, 10, 0x20},
-	{1, 10, 0x40},
+	/* Dial touch 1 - 8 (reverse order in data) */
 	{1, 10, 0x80},
+	{1, 10, 0x40},
+	{1, 10, 0x20},
+	{1, 10, 0x10},
+	{1, 10, 0x08},
+	{1, 10, 0x04},
+	{1, 10, 0x02},
+	{1, 10, 0x01},
 };
 #define BUTTONS_SIZE (sizeof(buttons) / sizeof(buttons[0]))
 

--- a/ctlra/midi.c
+++ b/ctlra/midi.c
@@ -74,7 +74,7 @@ struct ctlra_midi_t *ctlra_midi_open(const char *name,
 		printf("%s: error creating encoder\n", __func__);
 	snd_midi_event_no_status(m->encoder, 1);
 
-	res = snd_midi_event_new(32, &m->decoder);
+	res = snd_midi_event_new(1024, &m->decoder);
 	if (res < 0)
 		printf("%s: error creating decoder\n", __func__);
 	snd_midi_event_init(m->decoder);
@@ -121,7 +121,7 @@ int ctlra_midi_input_poll(struct ctlra_midi_t *s)
 {
 	int res;
 	int nbytes;
-	uint8_t buffer[3];
+	uint8_t buffer[1024];
 	snd_seq_event_t *seq_ev;
 
 	int input_pending = 1;
@@ -137,7 +137,7 @@ int ctlra_midi_input_poll(struct ctlra_midi_t *s)
 			return 0;
 		}
 
-		nbytes= snd_midi_event_decode(s->encoder, buffer, 3, seq_ev);
+		nbytes= snd_midi_event_decode(s->encoder, buffer, 1024, seq_ev);
 		if (nbytes < 0) {
 			continue;
 		}

--- a/ctlra/midi.c
+++ b/ctlra/midi.c
@@ -77,6 +77,7 @@ struct ctlra_midi_t *ctlra_midi_open(const char *name,
 	res = snd_midi_event_new(1024, &m->decoder);
 	if (res < 0)
 		printf("%s: error creating decoder\n", __func__);
+	snd_midi_event_no_status(m->decoder, 1);
 	snd_midi_event_init(m->decoder);
 
 	/* Keep callback / ud */

--- a/ctlra/midi.c
+++ b/ctlra/midi.c
@@ -130,16 +130,10 @@ int ctlra_midi_input_poll(struct ctlra_midi_t *s)
 
 	int input_pending = 1;
 
-	while (input_pending) {
+	while (input_pending > 0) {
 		res = snd_seq_event_input(s->seq, &seq_ev);
 		if(res < 0)
 			return 0;
-
-		input_pending = snd_seq_event_input_pending(s->seq, 1);
-		if (input_pending < 0) {
-			snd_seq_free_event(seq_ev);
-			return 0;
-		}
 
 		if (seq_ev->type == SND_SEQ_EVENT_SYSEX && seq_ev->data.ext.len > MAX_MSG_SIZE) {
 			// message too big, just skip it
@@ -158,6 +152,8 @@ int ctlra_midi_input_poll(struct ctlra_midi_t *s)
 		s->input_cb(nbytes, buffer, s->input_cb_ud);
 
 		snd_seq_free_event(seq_ev);
+
+		input_pending = snd_seq_event_input_pending(s->seq, 1);
 	}
 
 	return 0;


### PR DESCRIPTION
Hi Harry,

as you know I've been working on using Ctlra to make the Maschine Mk3 work for me on Linux. Works great, Ctlra is really nice!

However, along the way I found and fixed some bugs in the Mk3 backend (rev. 829eec81d81337910784ad7dbc13dabd09e6df7e) and I also had to enlarge the MIDI buffer sizes on the input side (rev. ea0a486fc0ff3aa3d3e2c1a0d39a82a251dd7c38), so that I can receive sysex messages which I'm using to control the daemon from outside, and also for Mackie feedback emulation.

I hope that these are acceptable as they are, if not please let me know how to improve them. Once this has been merged into mapping_v1, I can follow up with my extensive rework of the daemon example.

Thanks,  
Albert