### PR TITLE
Add install and c_args variables for examples

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -10,7 +10,9 @@ fluidsynth_dep = dependency('fluidsynth', required: false)
 foreach name: get_option('examples').split(',')
   example_src = []
   dependencies = []
+  c_args = []
   link_args = []
+  install = false
 
   subdir(name)
 
@@ -18,6 +20,8 @@ foreach name: get_option('examples').split(',')
              example_src,
              include_directories: ctlra_includes,
              dependencies : dependencies,
+             install : install,
+             c_args : c_args,
              link_args : link_args,
              link_with: ctlra)
 endforeach


### PR DESCRIPTION
Some minor (and backward-compatible) additions to the build system, so that compilation options can be passed to the examples subtargets by setting the `c_flags` variable, and the examples can optionally be installed along with the ctlra library by setting the `install` variable. (These variables will only affect the examples, and only if they are defined in an example's build file. Nothing changes by default.)